### PR TITLE
case sensitivity fixed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,16 @@ export class MoveEntry extends React.Component {
   };
   submit = () => this.makeMove(this.state.value);
   makeMove = (move) => {
+    const capitalizeAnywayArray = ['k', 'q', 'n', 'r']
+    if (capitalizeAnywayArray.includes(move.charAt(0))){
+      move = move.charAt(0).toUpperCase() + move.slice(1)
+    }
+    if (move.charAt(0) == 'b'){
+      const tmpMoveValid = this.props.gameClient.isMoveValid(move)
+      if(!tmpMoveValid){
+        move = move.charAt(0).toUpperCase() + move.slice(1)
+      }
+    }
     const moveValid = this.props.gameClient.isMoveValid(move);
     if (moveValid) {
       this.props.makeMove(move);


### PR DESCRIPTION
If we give an input like 'rd2' the app would show that it is not valid since it is expecting 'Rd2' for Rook to d2. I have made a fix to auto capitalize the first letter of every move except the pawn move as shown in the code. Fortunately we can capitalize k, q, n and r directly and issue comes only at b-file pawn move(b) and bishop move(B). I have accommodated that condition too.

I believe this would make input giving much easier. Please do check this.

PS: I am a complete noob in JS. I usually code in Python. Correct me if I am wrong :)